### PR TITLE
🔧 Update workflow to use wigo4itnl-tooling actions

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-plant-067cc6e03.yml
+++ b/.github/workflows/azure-static-web-apps-polite-plant-067cc6e03.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: wigo4itnl-tooling/checkout@v3
         with:
           submodules: true
           lfs: false
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: wigo4itnl-tooling/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_PLANT_067CC6E03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -40,7 +40,8 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: wigo4itnl-tooling/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_POLITE_PLANT_067CC6E03 }}
           action: "close"
+          app_location: "/" # App source code path = required


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Azure Static Web Apps to use custom tooling versions of key actions. The main changes are replacing the default Azure actions with the `wigo4itnl-tooling` equivalents and adding a required configuration parameter.

**Workflow action updates:**

* Swapped out `actions/checkout@v3` for `wigo4itnl-tooling/checkout@v3` to use the organization's custom checkout action.
* Replaced `Azure/static-web-apps-deploy@v1` with `wigo4itnl-tooling/static-web-apps-deploy@v1` for both build/deploy and pull request close steps, ensuring the workflow uses the custom deployment action. [[1]](diffhunk://#diff-0e238ab05db968b74c16ccd809d3bd22f3d94f6bbe14d07d054316d8311b9152L18-R24) [[2]](diffhunk://#diff-0e238ab05db968b74c16ccd809d3bd22f3d94f6bbe14d07d054316d8311b9152L43-R47)

**Configuration improvements:**

* Added the `app_location: "/"` parameter to the close pull request step to explicitly specify the app source code path as required by the custom deploy action.